### PR TITLE
Remove webr-*workers.js

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -1,13 +1,8 @@
 ---
 title: "Introduction to Statistics"
 author: "Nicola Rennie"
-format:
-  revealjs:
-    resources:
-    - webr-serviceworker.js
-    - webr-worker.js
+format: revealjs
 webr:
-  channel-type: "automatic"
   packages: ['ggplot2', 'dplyr']
 filters:
 - webr

--- a/webr-serviceworker.js
+++ b/webr-serviceworker.js
@@ -1,1 +1,0 @@
-importScripts('https://webr.r-wasm.org/v0.1.0/webr-serviceworker.js');

--- a/webr-worker.js
+++ b/webr-worker.js
@@ -1,1 +1,0 @@
-importScripts('https://webr.r-wasm.org/v0.1.0/webr-worker.js');


### PR DESCRIPTION
Awesome slide deck! 

One minor tweak: We no longer need the `webr-*workers.js` starting at v0.3.9 and above. 